### PR TITLE
Test logger edge cases

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["macos-11", ubuntu-20.04, "windows-latest"]
+        os: ["macos-11", "ubuntu-20.04", "windows-latest"]
         python_version: ["3.7", "3.8", "3.9", "3.10", "3.11-dev"]
     steps:
     - name: Setup python
@@ -41,7 +41,7 @@ jobs:
        python -m pytest --count=10 tests
 
     - name: Run benchmarks
-      if: matrix.python_version == '3.10'
+      if: matrix.python_version == '3.10' && matrix.os == 'ubuntu-20.04'
       run: |
        python -m pip install richbench
        richbench benchmarks/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.5.0
+
+* Logger now supports `sinfo=True` to add stack info to log messages
+* Fixed a bug where formatters using the `created` field were not correctly formatted
+* Fixed a bug where formatters using the thread id, `thread` field were formatted as signed int instead of unsigned long
+* Fixed a bug in the `__repr__` method of PercentStyle
+* Fixed a bug that the Logger.exception() method wasn't checking the log level for ERROR
+
 ## 0.4.0
 
 * Add Fuzzing and coverage configuration for Clang/GCC by @tonybaloney in https://github.com/microsoft/picologging/pull/26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 * Fixed a bug where formatters using the thread id, `thread` field were formatted as signed int instead of unsigned long
 * Fixed a bug in the `__repr__` method of PercentStyle
 * Fixed a bug that the Logger.exception() method wasn't checking the log level for ERROR
+* Fixed a bug in the formatting of exception messages
+* Setting the parent of a logger which has a NOTSET level will now update it's logging level to adopt the next set parent's level
 
 ## 0.4.0
 

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -9,8 +9,9 @@
 
 * Process name is not captured, `processName` will always be None
 * Thread name is not captured, `threadName` will always be None
-* LogRecord does not observe the `logging.logThreads`, `logging.logMultiprocessing`, or `logging.logProcesses` globals. It will always capture these values
+* LogRecord does not observe the `logging.logThreads`, `logging.logMultiprocessing`, or `logging.logProcesses` globals. It will *always* capture these values
 
 ## Logger
 
 * Logger will always default to the Sys.stderr and not observe (emittedNoHandlerWarning).
+* Having a logger with level NOTSET and a parent is supported, but changing the level of the parent *after* setting the parent field of the child will not propagate the level to the parent. See [#22](https://github.com/microsoft/picologging/issues/22)

--- a/src/picologging/__init__.py
+++ b/src/picologging/__init__.py
@@ -23,15 +23,6 @@ from ._picologging import (
 )  # NOQA
 from logging import (
     _checkLevel,
-    _STYLES,
-    CRITICAL,
-    DEBUG,
-    ERROR,
-    FATAL,
-    INFO,
-    NOTSET,
-    WARN,
-    WARNING,
     BufferingFormatter,
     StrFormatStyle,
     StringTemplateStyle,
@@ -42,6 +33,22 @@ import warnings
 
 __version__ = "0.4.0"
 
+CRITICAL = 50
+FATAL = CRITICAL
+ERROR = 40
+WARNING = 30
+WARN = WARNING
+INFO = 20
+DEBUG = 10
+NOTSET = 0
+
+BASIC_FORMAT = "%(levelname)s:%(name)s:%(message)s"
+
+_STYLES = {
+    '%': (PercentStyle, BASIC_FORMAT),
+    '{': (StrFormatStyle, '{levelname}:{name}:{message}'),
+    '$': (StringTemplateStyle, '${levelname}:${name}:${message}'),
+}
 
 class Manager:
     """

--- a/src/picologging/_picologging.cxx
+++ b/src/picologging/_picologging.cxx
@@ -116,9 +116,17 @@ PyMODINIT_FUNC PyInit__picologging(void)
   PyObject* print_exception = PyObject_GetAttrString(traceback, "print_exception");
   if (print_exception == NULL)
     return NULL;
+  PyObject* print_stack = PyObject_GetAttrString(traceback, "print_stack");
+  if (print_stack == NULL)
+    return NULL;
   Py_DECREF(traceback);
   if (PyModule_AddObject(m, "print_exception", print_exception) < 0){
     Py_DECREF(print_exception);
+    Py_DECREF(m);
+    return NULL;
+  }
+  if (PyModule_AddObject(m, "print_stack", print_stack) < 0){
+    Py_DECREF(print_stack);
     Py_DECREF(m);
     return NULL;
   }

--- a/src/picologging/formatter.cxx
+++ b/src/picologging/formatter.cxx
@@ -111,6 +111,10 @@ PyObject* Formatter_format(Formatter *self, PyObject *record){
             return nullptr;
 
         if (logRecord->excInfo != Py_None && logRecord->excText == Py_None){
+            if (!PyTuple_Check(logRecord->excInfo)) {
+                PyErr_Format(PyExc_TypeError, "LogRecord.excInfo must be a tuple.");
+                return nullptr;
+            }
             PyObject* mod = PICOLOGGING_MODULE(); // borrowed reference
             PyObject* modDict = PyModule_GetDict(mod); // borrowed reference
             PyObject* print_exception = PyDict_GetItemString(modDict, "print_exception"); // PyDict_GetItemString returns a borrowed reference

--- a/src/picologging/formatter.cxx
+++ b/src/picologging/formatter.cxx
@@ -152,8 +152,10 @@ PyObject* Formatter_format(Formatter *self, PyObject *record){
             Py_DECREF(sio);
             Py_DECREF(sio_cls);
             Py_DECREF(print_exception);
-            if (!PYUNICODE_ENDSWITH(s, self->_const_line_break)){
-                PyUnicode_Append(&s, self->_const_line_break);
+            if (PYUNICODE_ENDSWITH(s, self->_const_line_break)){
+                PyObject* s2 = PyUnicode_Substring(s, 0, PyUnicode_GetLength(s) - 1);
+                Py_DECREF(s);
+                s = s2;
             }
             Py_XDECREF(logRecord->excText);
             logRecord->excText = s; // Use borrowed ref

--- a/src/picologging/logger.cxx
+++ b/src/picologging/logger.cxx
@@ -250,7 +250,7 @@ PyObject* Logger_logAndHandle(Logger *self, PyObject *args, PyObject *kwds, unsi
         exc_info = Py_None;
         Py_INCREF(exc_info);
     } else {
-        if (PyExceptionClass_Check(exc_info)){
+        if (PyExceptionInstance_Check(exc_info)){
             PyObject * unpackedExcInfo = PyTuple_New(3);
             PyObject * excType = (PyObject*)Py_TYPE(exc_info);
             PyTuple_SET_ITEM(unpackedExcInfo, 0, excType);
@@ -261,7 +261,7 @@ PyObject* Logger_logAndHandle(Logger *self, PyObject *args, PyObject *kwds, unsi
             PyTuple_SET_ITEM(unpackedExcInfo, 2, traceback);
             Py_INCREF(traceback);
             exc_info = unpackedExcInfo;
-        } else if (!PyTuple_CheckExact(exc_info)){ // Probably Py_TRUE
+        } else if (!PyTuple_CheckExact(exc_info)){ // Probably Py_TRUE, fetch current exception as tuple
             PyObject * unpackedExcInfo = PyTuple_New(3);
             PyErr_GetExcInfo(&PyTuple_GET_ITEM(unpackedExcInfo, 0), &PyTuple_GET_ITEM(unpackedExcInfo, 1), &PyTuple_GET_ITEM(unpackedExcInfo, 2));
             exc_info = unpackedExcInfo;

--- a/src/picologging/logger.cxx
+++ b/src/picologging/logger.cxx
@@ -184,7 +184,7 @@ LogRecord* Logger_logMessageAsRecord(Logger* self, unsigned short level, PyObjec
         }
         if (PyObject_CallFunctionObjArgs(
             print_stack,
-            orig_f,
+            Py_None,
             Py_None,
             sio,
             NULL) == nullptr)

--- a/src/picologging/logger.hxx
+++ b/src/picologging/logger.hxx
@@ -32,6 +32,7 @@ typedef struct LoggerT {
     PyObject* _const_exc_info;
     PyObject* _const_extra;
     PyObject* _const_stack_info;
+    PyObject* _const_line_break;
 
     StreamHandler* _fallback_handler;
 } Logger ;
@@ -42,14 +43,15 @@ PyObject* Logger_getEffectiveLevel(Logger *self);
 PyObject* Logger_dealloc(Logger *self);
 PyObject* Logger_addHandler(Logger *self, PyObject *handler);
 
-PyObject* Logger_debug(Logger *self, PyObject *const *args, Py_ssize_t nargs, PyObject *kwds);
-PyObject* Logger_info(Logger *self, PyObject *const *args, Py_ssize_t nargs, PyObject *kwds);
-PyObject* Logger_warning(Logger *self, PyObject *const *args, Py_ssize_t nargs, PyObject *kwds);
-PyObject* Logger_fatal(Logger *self, PyObject *const *args, Py_ssize_t nargs, PyObject *kwds);
-PyObject* Logger_error(Logger *self, PyObject *const *args, Py_ssize_t nargs, PyObject *kwds);
-PyObject* Logger_critical(Logger *self, PyObject *const *args, Py_ssize_t nargs, PyObject *kwds);
-PyObject* Logger_exception(Logger *self, PyObject *const *args, Py_ssize_t nargs, PyObject *kwds);
-PyObject* Logger_log(Logger *self, PyObject *const *args, Py_ssize_t nargs, PyObject *kwds);
+PyObject* Logger_logAndHandle(Logger *self, PyObject *args, PyObject *kwds, unsigned short level);
+PyObject* Logger_debug(Logger *self, PyObject *args, PyObject *kwds);
+PyObject* Logger_info(Logger *self, PyObject *args, PyObject *kwds);
+PyObject* Logger_warning(Logger *self, PyObject *args, PyObject *kwds);
+PyObject* Logger_fatal(Logger *self, PyObject *args, PyObject *kwds);
+PyObject* Logger_error(Logger *self, PyObject *args, PyObject *kwds);
+PyObject* Logger_critical(Logger *self, PyObject *args, PyObject *kwds);
+PyObject* Logger_exception(Logger *self, PyObject *args, PyObject *kwds);
+PyObject* Logger_log(Logger *self, PyObject *args, PyObject *kwds);
 
 LogRecord* Logger_logMessageAsRecord(Logger* self, unsigned short level, PyObject *msg, PyObject *args, PyObject * exc_info, PyObject *extra, PyObject *stack_info, int stacklevel=1);
 

--- a/src/picologging/logger.hxx
+++ b/src/picologging/logger.hxx
@@ -57,5 +57,6 @@ LogRecord* Logger_logMessageAsRecord(Logger* self, unsigned short level, PyObjec
 
 extern PyTypeObject LoggerType;
 #define Logger_CheckExact(op) Py_IS_TYPE(op, &LoggerType)
+#define Logger_Check(op) PyObject_TypeCheck(op, &LoggerType)
 
 #endif // PICOLOGGING_LOGGER_H

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -1,4 +1,5 @@
 import io
+from re import L
 from typing import Type
 import picologging
 import logging
@@ -220,13 +221,60 @@ def test_add_remove_handlers():
 @pytest.mark.parametrize("level_config", levels)
 def test_log_and_handle(level_config):
     logger = picologging.Logger("test", level=level_config)
-    assert not logger.info("gello")
-    assert not logger.debug("hello")
-    assert not logger.warning("hello")
-    assert not logger.error("hello")
-    assert not logger.fatal("hello")
-    assert not logger.critical("hello")
-    assert not logger.log(level_config, "hello")
+    tmp = io.StringIO()
+    logger.addHandler(picologging.StreamHandler(tmp))
+    assert not logger.info("info_message")
+    assert not logger.debug("debug_message")
+    assert not logger.warning("warning_message")
+    assert not logger.error("error_message")
+    assert not logger.fatal("fatal_message")
+    assert not logger.critical("critical_message")
+    assert not logger.log(level_config, "log_message")
+
+    tmp_value = tmp.getvalue()
+
+    if level_config <= picologging.DEBUG and level_config != picologging.NOTSET:
+        assert "debug_message" in tmp_value
+    else:
+        assert "debug_message" not in tmp_value
+    if level_config <= picologging.INFO and level_config != picologging.NOTSET:
+        assert "info_message" in tmp_value
+    else:
+        assert "info_message" not in tmp_value
+    if level_config <= picologging.WARNING and level_config != picologging.NOTSET:
+        assert "warning_message" in tmp_value
+    else:
+        assert "warning_message" not in tmp_value
+    if level_config <= picologging.ERROR and level_config != picologging.NOTSET:
+        assert "error_message" in tmp_value
+    else:
+        assert "error_message" not in tmp_value
+    if level_config <= picologging.FATAL and level_config != picologging.NOTSET:
+        assert "fatal_message" in tmp_value
+    else:
+        assert "fatal_message" not in tmp_value
+    if level_config <= picologging.CRITICAL and level_config != picologging.NOTSET:
+        assert "critical_message" in tmp_value
+    else:
+        assert "critical_message" not in tmp_value
+    assert "log_message" in tmp_value
+
+def test_log_xx_bad_arguments():
+    logger = picologging.Logger("test", level=picologging.DEBUG)
+    
+    with pytest.raises(TypeError):
+        logger.info()
+    with pytest.raises(TypeError):
+        logger.debug()
+    with pytest.raises(TypeError):
+        logger.warning()
+    with pytest.raises(TypeError):
+        logger.error()
+    with pytest.raises(TypeError):
+        logger.fatal()
+    with pytest.raises(TypeError):
+        logger.critical()
+
 
 def test_log_bad_arguments():
     logger = picologging.Logger("test")
@@ -235,3 +283,48 @@ def test_log_bad_arguments():
     
     with pytest.raises(TypeError):
         logger.log()
+
+
+def test_notset_parent_level_match():
+    logger_child = picologging.Logger("child", picologging.NOTSET)
+    logger_parent = picologging.Logger("parent", picologging.DEBUG)
+    logger_child.parent = logger_parent
+
+    parent_io = io.StringIO()
+    child_io = io.StringIO()
+    logger_child.addHandler(picologging.StreamHandler(child_io))
+    logger_parent.addHandler(picologging.StreamHandler(parent_io))
+
+    logger_child.info("child message")
+    logger_parent.info("parent message")
+    parent_value = parent_io.getvalue()
+    child_value = child_io.getvalue()
+    assert "child message" in child_value
+    assert "child message" in parent_value
+    assert "parent message" in parent_value
+    assert "parent message" not in child_value
+
+
+def test_nested_frame_stack():
+    logger = picologging.Logger("test", level=picologging.DEBUG)
+    tmp = io.StringIO()
+    logger.addHandler(picologging.StreamHandler(tmp))
+    def f():
+        def g():
+            logger.info("message", stack_info=True)
+        g()
+    f()
+    result = tmp.getvalue()
+    assert "message" in result
+    assert " in g\n" in result
+    assert " in f\n" in result
+
+def test_exception_object_as_exc_info():
+    e = Exception("arghhh!!")
+    logger = picologging.Logger("test", level=picologging.DEBUG)
+    tmp = io.StringIO()
+    logger.addHandler(picologging.StreamHandler(tmp))
+    logger.info("message", exc_info=e)
+    result = tmp.getvalue()
+    assert "message" in result
+    assert "arghhh!!" in result

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -1,6 +1,4 @@
 import io
-from re import L
-from typing import Type
 import picologging
 import logging
 import pytest
@@ -165,7 +163,7 @@ def test_logger_with_explicit_level(capsys):
     assert cap.err == ""
 
 def test_exception_capture():
-    logger = picologging.getLogger(__name__)
+    logger = picologging.Logger("test", logging.DEBUG)
     tmp = io.StringIO()
     handler = picologging.StreamHandler(tmp)
     logger.addHandler(handler)

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -56,8 +56,8 @@ def test_get_effective_level():
 def test_dodgy_parents():
     logger = picologging.Logger('test')
     parent = "potato"
-    logger.parent = parent
-    with pytest.raises(AttributeError):
+    with pytest.raises(TypeError):
+        logger.parent = parent
         logger.getEffectiveLevel()
 
 
@@ -313,6 +313,29 @@ def test_notset_parent_level_match():
     assert "parent message" in parent_value
     assert "parent message" not in child_value
 
+def test_error_parent_level():
+    logger_child = picologging.Logger("child", picologging.WARNING)
+    logger_parent = picologging.Logger("parent", picologging.ERROR)
+    logger_child.parent = logger_parent
+
+    parent_io = io.StringIO()
+    child_io = io.StringIO()
+    logger_child.addHandler(picologging.StreamHandler(child_io))
+    logger_parent.addHandler(picologging.StreamHandler(parent_io))
+
+    logger_child.info("info message")
+    logger_child.warning("warning message")
+    logger_child.error("error message")
+
+    parent_value = parent_io.getvalue()
+    child_value = child_io.getvalue()
+
+    assert "info message" not in child_value
+    assert "info message" not in parent_value
+    assert "warning message" in child_value
+    assert "warning message" in parent_value
+    assert "error message" in child_value
+    assert "error message" in parent_value
 
 def test_nested_frame_stack():
     logger = picologging.Logger("test", level=picologging.DEBUG)

--- a/tests/unit/test_picologging.py
+++ b/tests/unit/test_picologging.py
@@ -1,5 +1,6 @@
 import sys
 import picologging
+import logging
 import pytest
 
 levels = [
@@ -47,11 +48,11 @@ def test_root_logger_error(capsys):
 
 def test_root_logger_exception(capsys):
     picologging.root.handlers = []
-    picologging.exception("test")
+    picologging.exception("test", exc_info=Exception("bork bork bork"))
 
     cap = capsys.readouterr()
     assert cap.out == ""
-    assert cap.err == "ERROR:root:test\n"
+    assert cap.err == "ERROR:root:test\nException: bork bork bork\n"
 
 def test_root_logger_warning(capsys):
     picologging.root.handlers = []


### PR DESCRIPTION
Identifies 3 bugs:

1. Exception info with `exc_info` as an instance of exception does not format correctly
2. `stack_info`/`sinfo` is not implemented correctly and doesn't add the stack trace to the log message
3. child/parent NOTSET rules are not being adhered to

```python
def test_notset_parent_level_match():
    logger_child = picologging.Logger("child", picologging.NOTSET)
    logger_parent = picologging.Logger("parent", picologging.DEBUG)
    logger_child.parent = logger_parent

    parent_io = io.StringIO()
    child_io = io.StringIO()
    logger_child.addHandler(picologging.StreamHandler(child_io))
    logger_parent.addHandler(picologging.StreamHandler(parent_io))

    logger_child.info("child message")
    logger_parent.info("parent message")
    parent_value = parent_io.getvalue()
    child_value = child_io.getvalue()
    assert "child message" in child_value
    assert "child message" in parent_value
    assert "parent message" in parent_value
    assert "parent message" not in child_value
```