### PR TITLE
Add benchmakrs for handlers

### DIFF
--- a/benchmarks/bench_handlers.py
+++ b/benchmarks/bench_handlers.py
@@ -1,0 +1,72 @@
+import tempfile
+import logging
+import picologging
+import logging.handlers as logging_handlers
+import picologging.handlers as picologging_handlers
+
+
+def filehandler_logging():
+    with tempfile.NamedTemporaryFile() as f:
+        logger = logging.Logger("test", logging.DEBUG)
+        handler = logging.FileHandler(f.name)
+        logger.handlers.append(handler)
+
+        for _ in range(1_000):
+            logger.debug("There has been a logging issue")
+
+
+def filehandler_picologging():
+    with tempfile.NamedTemporaryFile() as f:
+        logger = picologging.Logger("test", picologging.DEBUG)
+        handler = picologging.FileHandler(f.name)
+        logger.handlers.append(handler)
+
+        for _ in range(1_000):
+            logger.debug("There has been a picologging issue")
+
+
+def watchedfilehandler_logging():
+    with tempfile.NamedTemporaryFile() as f:
+        logger = logging.Logger("test", logging.DEBUG)
+        handler = logging_handlers.WatchedFileHandler(f.name)
+        logger.handlers.append(handler)
+
+        for _ in range(1_000):
+            logger.debug("There has been a logging issue")
+
+
+def watchedfilehandler_picologging():
+    with tempfile.NamedTemporaryFile() as f:
+        logger = picologging.Logger("test", picologging.DEBUG)
+        handler = picologging_handlers.WatchedFileHandler(f.name)
+        logger.handlers.append(handler)
+
+        for _ in range(1_000):
+            logger.debug("There has been a picologging issue")
+
+
+def rotatingfilehandler_logging():
+    with tempfile.NamedTemporaryFile() as f:
+        logger = logging.Logger("test", logging.DEBUG)
+        handler = logging_handlers.RotatingFileHandler(f.name, maxBytes=10_000, backupCount=5)
+        logger.handlers.append(handler)
+
+        for _ in range(1_000):
+            logger.debug("There has been a logging issue")
+
+
+def rotatingfilehandler_picologging():
+    with tempfile.NamedTemporaryFile() as f:
+        logger = picologging.Logger("test", picologging.DEBUG)
+        handler = picologging_handlers.RotatingFileHandler(f.name, maxBytes=10_000, backupCount=5)
+        logger.handlers.append(handler)
+
+        for _ in range(1_000):
+            logger.debug("There has been a picologging issue")
+
+
+__benchmarks__ = [
+    (filehandler_logging, filehandler_picologging, "FileHandler()"),
+    (watchedfilehandler_logging, watchedfilehandler_picologging, "WatchedFileHandler()"),
+    (rotatingfilehandler_logging, rotatingfilehandler_picologging, "RotatingFileHandler()"),
+]


### PR DESCRIPTION
Closes #30.
Adds benchmarks for `FileHandler`, `WatchedFileHandler` and `RotatingFileHandler`.

The `RotatingFileHandler` would perform better with larger `maxBytes` like `1MB` and more logs so it would do less IO which is closer to real-world use-case and around x3 times faster than logging but there are two points:
- It would make the benchmarks take longer
- this could apply to all other benchmarks, increasing the number of logs  will make a larger difference but I'm not sure if that's what's wanted here.

<img width="1072" alt="Screenshot 2022-07-03 at 15 18 56" src="https://user-images.githubusercontent.com/19784933/177042179-8a221a1c-9cb3-4a16-a03a-79ab9e8f35b7.png">

