### PR TITLE
Make getLevelName work level name arguments

### DIFF
--- a/src/picologging/_picologging.cxx
+++ b/src/picologging/_picologging.cxx
@@ -60,7 +60,8 @@ static PyObject *getLevelName(PyObject *self, PyObject *level) {
     if (levelName.length() > 0) {
       return PyUnicode_FromString(levelName.c_str());
     }
-    return PyUnicode_FromFormat("Level %d", levelValue);
+    PyErr_Format(PyExc_ValueError, "Invalid level value: %d", levelValue);
+    return nullptr;
   }
 
   if (PyUnicode_Check(level)) {
@@ -68,7 +69,8 @@ static PyObject *getLevelName(PyObject *self, PyObject *level) {
     if (levelValue >= 0) {
       return PyLong_FromLong(levelValue);
     }
-    return PyUnicode_FromFormat("Level %U", level);
+    PyErr_Format(PyExc_ValueError, "Invalid level value: %U", level);
+    return nullptr;
   }
 
   PyErr_SetString(PyExc_TypeError, "level must be an integer or a string.");

--- a/src/picologging/_picologging.cxx
+++ b/src/picologging/_picologging.cxx
@@ -13,7 +13,7 @@
 #include "handler.hxx"
 #include "streamhandler.hxx"
 
-const std::unordered_map<unsigned short, std::string> LEVELS_TO_NAMES = {
+const std::unordered_map<short, std::string> LEVELS_TO_NAMES = {
   {LOG_LEVEL_DEBUG, "DEBUG"},
   {LOG_LEVEL_INFO, "INFO"},
   {LOG_LEVEL_WARNING, "WARNING"},
@@ -22,8 +22,17 @@ const std::unordered_map<unsigned short, std::string> LEVELS_TO_NAMES = {
   {LOG_LEVEL_NOTSET, "NOTSET"},
 };
 
-std::string _getLevelName(unsigned short level) {
-  std::unordered_map<unsigned short, std::string>::const_iterator it;
+const std::unordered_map<std::string, short> NAMES_TO_LEVELS = {
+  {"DEBUG", LOG_LEVEL_DEBUG},
+  {"INFO", LOG_LEVEL_INFO},
+  {"WARNING", LOG_LEVEL_WARNING},
+  {"ERROR", LOG_LEVEL_ERROR},
+  {"CRITICAL", LOG_LEVEL_CRITICAL},
+  {"NOTSET", LOG_LEVEL_NOTSET},
+};
+
+std::string _getLevelName(short level) {
+  std::unordered_map<short, std::string>::const_iterator it;
   it = LEVELS_TO_NAMES.find(level);
 
   if (it == LEVELS_TO_NAMES.end()){
@@ -33,14 +42,37 @@ std::string _getLevelName(unsigned short level) {
   return it->second;
 }
 
-static PyObject *getLevelName(PyObject *self, PyObject *level) {
-    if (!PyLong_Check(level)) {
-        PyErr_SetString(PyExc_TypeError, "level must be an integer");
-        return NULL;
-    }
+short _getLevelByName(std::string levelName) {
+  std::unordered_map<std::string, short>::const_iterator it;
+  it = NAMES_TO_LEVELS.find(levelName);
 
-    std::string levelName = _getLevelName((unsigned short)PyLong_AsUnsignedLongMask(level));
-    return PyUnicode_FromString(levelName.c_str());
+  if (it == NAMES_TO_LEVELS.end()){
+    return -1;
+  }
+
+  return it->second;
+}
+
+static PyObject *getLevelName(PyObject *self, PyObject *level) {
+  if (PyLong_Check(level)) {
+    short levelValue = (short)PyLong_AsLong(level);
+    std::string levelName = _getLevelName(levelValue);
+    if (levelName.length() > 0) {
+      return PyUnicode_FromString(levelName.c_str());
+    }
+    return PyUnicode_FromFormat("Level %d", levelValue);
+  }
+
+  if (PyUnicode_Check(level)) {
+    short levelValue = _getLevelByName(PyUnicode_AsUTF8(level));
+    if (levelValue >= 0) {
+      return PyLong_FromLong(levelValue);
+    }
+    return PyUnicode_FromFormat("Level %U", level);
+  }
+
+  PyErr_SetString(PyExc_TypeError, "level must be an integer or a string.");
+  return NULL;
 }
 
 //-----------------------------------------------------------------------------

--- a/src/picologging/picologging.hxx
+++ b/src/picologging/picologging.hxx
@@ -5,7 +5,7 @@
 #define PICOLOGGING_H
 
 extern struct PyModuleDef _picologging_module;
-std::string _getLevelName(unsigned short);
+std::string _getLevelName(short);
 
 #define PICOLOGGING_MODULE() PyState_FindModule(&_picologging_module)
 

--- a/tests/unit/test_picologging.py
+++ b/tests/unit/test_picologging.py
@@ -17,13 +17,20 @@ levels = [
 def test_getlevelname(level, level_name):
     assert picologging.getLevelName(level) == level_name
     assert picologging.getLevelName(level_name) == level
-    assert picologging.getLevelName(100) == "Level 100"
-    assert picologging.getLevelName("EXample") == "Level EXample"
 
 
-def test_getlevelname_invalid_level():
+def test_value_error_invalid_string_names():
+    with pytest.raises(ValueError):
+        assert picologging.getLevelName("EXample") == "Level EXample"
+
+
+junk_level_names = [None, 3.2, (), [], {}]
+
+
+@pytest.mark.parametrize("level", junk_level_names)
+def test_getlevelname_invalid_level(level):
     with pytest.raises(TypeError):
-        picologging.getLevelName(None)
+        picologging.getLevelName(level)
 
 
 def test_root_logger_critical(capsys):

--- a/tests/unit/test_picologging.py
+++ b/tests/unit/test_picologging.py
@@ -16,13 +16,14 @@ levels = [
 @pytest.mark.parametrize("level, level_name", levels)
 def test_getlevelname(level, level_name):
     assert picologging.getLevelName(level) == level_name
+    assert picologging.getLevelName(level_name) == level
+    assert picologging.getLevelName(100) == "Level 100"
+    assert picologging.getLevelName("EXample") == "Level EXample"
 
 
 def test_getlevelname_invalid_level():
-    assert picologging.getLevelName(100) == ""
-
     with pytest.raises(TypeError):
-        picologging.getLevelName("100")
+        picologging.getLevelName(None)
 
 
 def test_root_logger_critical(capsys):


### PR DESCRIPTION
Fixes #51  to be compatible with `logging`.

I think there's some issue with the coverage, all changes are covered but it's assuming the removed lines won't be covered.