### PR TITLE
Fix Logger setLevel not resetting other levels

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -17,9 +17,9 @@
 
 # -- Project information -----------------------------------------------------
 
-project = 'picologging'
-copyright = '2022, Microsoft'
-author = 'Microsoft'
+project = "picologging"
+copyright = "2022, Microsoft"
+author = "Microsoft"
 
 
 # -- General configuration ---------------------------------------------------
@@ -27,10 +27,10 @@ author = 'Microsoft'
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['sphinx.ext.autodoc', 'sphinx.ext.viewcode']
+extensions = ["sphinx.ext.autodoc", "sphinx.ext.viewcode"]
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -43,9 +43,9 @@ exclude_patterns = []
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'furo'
+html_theme = "furo"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = ["_static"]

--- a/src/picologging/logger.cxx
+++ b/src/picologging/logger.cxx
@@ -80,15 +80,30 @@ int Logger_init(Logger *self, PyObject *args, PyObject *kwds)
     Py_INCREF(self->name);
     self->level = level;
 
+    self->enabledForDebug = false;
+    self->enabledForInfo = false;
+    self->enabledForWarning = false;
+    self->enabledForError = false;
+    self->enabledForCritical = false;
     switch (getEffectiveLevel(self)){
         case LOG_LEVEL_DEBUG:
             self->enabledForDebug = true;
+            self->enabledForInfo = true;
+            self->enabledForWarning = true;
+            self->enabledForError = true;
+            self->enabledForCritical = true;
         case LOG_LEVEL_INFO:
             self->enabledForInfo = true;
+            self->enabledForWarning = true;
+            self->enabledForError = true;
+            self->enabledForCritical = true;
         case LOG_LEVEL_WARNING:
             self->enabledForWarning = true;
+            self->enabledForError = true;
+            self->enabledForCritical = true;
         case LOG_LEVEL_ERROR:
             self->enabledForError = true;
+            self->enabledForCritical = true;
         case LOG_LEVEL_CRITICAL:
             self->enabledForCritical = true;
     }
@@ -124,18 +139,35 @@ PyObject* Logger_setLevel(Logger *self, PyObject *level) {
         return NULL;
     }
     self->level = (unsigned short)PyLong_AsUnsignedLongMask(level);
+
+    self->enabledForDebug = false;
+    self->enabledForInfo = false;
+    self->enabledForWarning = false;
+    self->enabledForError = false;
+    self->enabledForCritical = false;
     switch (getEffectiveLevel(self)){
         case LOG_LEVEL_DEBUG:
             self->enabledForDebug = true;
+            self->enabledForInfo = true;
+            self->enabledForWarning = true;
+            self->enabledForError = true;
+            self->enabledForCritical = true;
         case LOG_LEVEL_INFO:
             self->enabledForInfo = true;
+            self->enabledForWarning = true;
+            self->enabledForError = true;
+            self->enabledForCritical = true;
         case LOG_LEVEL_WARNING:
             self->enabledForWarning = true;
+            self->enabledForError = true;
+            self->enabledForCritical = true;
         case LOG_LEVEL_ERROR:
             self->enabledForError = true;
+            self->enabledForCritical = true;
         case LOG_LEVEL_CRITICAL:
             self->enabledForCritical = true;
     }
+
     Py_RETURN_NONE;
     // TODO: Should reset parent/child loggers
 }
@@ -497,18 +529,34 @@ Logger_set_parent(Logger *self, PyObject *value, void *Py_UNUSED(ignored))
     Py_XDECREF(self->parent);
     self->parent = value;
     // Rescan parent levels.
+    self->enabledForDebug = false;
+    self->enabledForInfo = false;
+    self->enabledForWarning = false;
+    self->enabledForError = false;
+    self->enabledForCritical = false;
     switch (getEffectiveLevel(self)){
         case LOG_LEVEL_DEBUG:
             self->enabledForDebug = true;
+            self->enabledForInfo = true;
+            self->enabledForWarning = true;
+            self->enabledForError = true;
+            self->enabledForCritical = true;
         case LOG_LEVEL_INFO:
             self->enabledForInfo = true;
+            self->enabledForWarning = true;
+            self->enabledForError = true;
+            self->enabledForCritical = true;
         case LOG_LEVEL_WARNING:
             self->enabledForWarning = true;
+            self->enabledForError = true;
+            self->enabledForCritical = true;
         case LOG_LEVEL_ERROR:
             self->enabledForError = true;
+            self->enabledForCritical = true;
         case LOG_LEVEL_CRITICAL:
             self->enabledForCritical = true;
     }
+
     return 0;
 }
 

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -383,3 +383,24 @@ def test_exception_object_as_exc_info():
     result = tmp.getvalue()
     assert "message" in result
     assert "arghhh!!" in result
+
+
+def test_logger_setlevel_resets_other_levels():
+    stream = io.StringIO()
+    handler = picologging.StreamHandler(stream)
+    logger = picologging.getLogger("test")
+    logger.addHandler(handler)
+    logger.setLevel(picologging.WARNING)
+
+    logger.debug("test")
+    assert stream.getvalue() == ""
+
+    logger.warning("test")
+    assert stream.getvalue() == "test\n"
+
+    logger.setLevel(picologging.ERROR)
+    logger.warning("test")
+    assert stream.getvalue() == "test\n"
+
+    logger.error("test")
+    assert stream.getvalue() == "test\ntest\n"


### PR DESCRIPTION
Fixes https://github.com/microsoft/picologging/issues/56

At first I thought it should only reset lower levels, which is a bit less verbose, but it should also reset higher levels:

for example:

```py
logger.setLevel(picologging.INFO)

# This should enable levels ERROR and CRITICAL but also disable DEBUG, INFO, WARNING
logger.setLevel(picologging.ERROR)
```