### PR TITLE
Set Manager on root Logger

### DIFF
--- a/src/picologging/__init__.py
+++ b/src/picologging/__init__.py
@@ -111,7 +111,7 @@ class Manager:
 
 
 root = Logger(name="root", level=WARNING)
-manager = Manager(root)
+root.manager = Manager(root)
 
 
 def basicConfig(**kwargs):
@@ -243,7 +243,7 @@ def getLogger(name=None):
     """
     if not name or isinstance(name, str) and name == root.name:
         return root
-    return manager.getLogger(name)
+    return root.manager.getLogger(name)
 
 
 def critical(msg, *args, **kwargs):


### PR DESCRIPTION
Trying to work on the `dictConfig` I see `Manager` instance should be set on the root Logger because `root` is what is exposed as module variables, not manager:
https://github.com/microsoft/picologging/blob/a0aa8c610a950a53bbdd6dc78b5f163c6428bfd5/src/picologging/__init__.pyi#L338

And when accessing root the manager is None.