### PR TITLE
Upgrade Github CodeQL to V2

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -54,7 +54,10 @@ jobs:
       # Using 'latest' branch, the most recent CMake and ninja are installed.
       uses: lukka/get-cmake@latest
     - name: Install and build package
-      run: python -m pip install -e .
+      run: |
+        python -m pip install -U pip
+        python -m pip install scikit-build
+        python -m pip install -v .
   
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -41,7 +41,7 @@ jobs:
       uses: actions/checkout@v3
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
 
@@ -68,7 +68,7 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2
 
   analyze-python:
     name: Analyze Python Code
@@ -88,7 +88,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v1
+        uses: github/codeql-action/init@v2
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -97,7 +97,7 @@ jobs:
           # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v1
+        uses: github/codeql-action/autobuild@v2
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 https://git.io/JvXDl
@@ -111,7 +111,7 @@ jobs:
       #   make release
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v1
+        uses: github/codeql-action/analyze@v2
 
   coverage:
     name: Coverage


### PR DESCRIPTION
- Upgrade Github CodeQL to V2 since V1 will be deprecated in December 2022 and receive no updates
- Fix the the pipeline failing for cpp files not found.