### PR TITLE
Fix dictconfig resetting child loggers

### DIFF
--- a/src/picologging/__init__.py
+++ b/src/picologging/__init__.py
@@ -90,11 +90,6 @@ class Manager:
         Get a logger with the specified name (channel name), creating it
         if it doesn't yet exist. This name is a dot-separated hierarchical
         name, such as "a", "a.b", "a.b.c" or similar.
-
-        If a PlaceHolder existed for the specified name [i.e. the logger
-        didn't exist but a child of it did], replace it with the created
-        logger and fix up the parent/child references which pointed to the
-        placeholder to now point to the logger.
         """
         if name in self.loggerDict:
             rv = self.loggerDict[name]

--- a/src/picologging/config.py
+++ b/src/picologging/config.py
@@ -43,10 +43,9 @@ def _handle_existing_loggers(existing, child_loggers, disable_existing):
     for log in existing:
         logger = root.manager.loggerDict[log]
         if log in child_loggers:
-            if not isinstance(logger, picologging.PlaceHolder):
-                logger.setLevel(picologging.NOTSET)
-                logger.handlers = []
-                logger.propagate = True
+            logger.setLevel(picologging.NOTSET)
+            logger.handlers = []
+            logger.propagate = True
         else:
             logger.disabled = disable_existing
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -173,3 +173,42 @@ def test_dictconfig_filters_exception():
 
     with pytest.raises(ValueError):
         dictConfig(config)
+
+
+def test_reconfigure_dictconfig_with_child_loggers():
+    logger = picologging.getLogger("test_config")
+    logger.addHandler(picologging.StreamHandler())
+
+    config = {
+        "version": 1,
+        "loggers": {
+            "test_config.module": {
+                "handlers": ["console"],
+                "level": "INFO",
+            },
+        },
+        "handlers": {
+            "console": {
+                "class": "picologging.StreamHandler",
+            },
+        },
+    }
+
+    dictConfig(config)
+
+    config = {
+        "version": 1,
+        "loggers": {
+            "test_config": {
+                "handlers": ["console"],
+                "level": "INFO",
+            },
+        },
+        "handlers": {
+            "console": {
+                "class": "picologging.StreamHandler",
+            },
+        },
+    }
+
+    dictConfig(config)


### PR DESCRIPTION
Fixes #67 .

The code was using the CPython version with PlaceHolder, it didn't have test coverage. This adds the tests and fixes the issue.