### PR TITLE
Add processName for Linux

### DIFF
--- a/docs/source/limitations.rst
+++ b/docs/source/limitations.rst
@@ -12,7 +12,7 @@ Formatter Interface
 LogRecord
 ---------
 
-* Process name is not captured, `processName` will always be None (Process ID is captured).
+* Process name is not captured when using `multiprocessing` on Windows and macOS, it will be None.
 * Thread name is not captured, `threadName` will always be None. (Thread ID is captured).
 * LogRecord does not observe the `logging.logThreads`, `logging.logMultiprocessing`, or `logging.logProcesses` globals. It will *always* capture process and thread ID because the check is slower than the capture.
 


### PR DESCRIPTION
This PR does two things:

- sets default `processName` to `MainProcess` when not using `multiprocessing` as per [logging](https://github.com/python/cpython/blob/main/Lib/logging/__init__.py#L351) which is not `None` by default..
- sets the correct `processName` when using `multiprocessing` on `Linux`.

I'm not sure if/how we could have it as a flag since this is a native extension to enable/disable process logging.