### PR TITLE
Making LogRecord class derivable

### DIFF
--- a/src/picologging/logrecord.cxx
+++ b/src/picologging/logrecord.cxx
@@ -372,7 +372,7 @@ PyTypeObject LogRecordType = {
     PyObject_GenericGetAttr,                    /* tp_getattro */
     PyObject_GenericSetAttr,                    /* tp_setattro */
     0,                                          /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT  ,  /* tp_flags */
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,  /* tp_flags */
     PyDoc_STR("LogRecord objects are used to hold information about log events."),  /* tp_doc */
     0,                                          /* tp_traverse */
     0,                                          /* tp_clear */

--- a/tests/unit/test_logrecord.py
+++ b/tests/unit/test_logrecord.py
@@ -110,7 +110,10 @@ def test_process_info():
 def test_logrecord_subclass():
     class DerivedLogRecord(LogRecord):
         pass
-    record = DerivedLogRecord("hello", logging.WARNING, __file__, 123, "bork boom", (), None)
+
+    record = DerivedLogRecord(
+        "hello", logging.WARNING, __file__, 123, "bork boom", (), None
+    )
 
     assert DerivedLogRecord.__base__ is LogRecord
     assert record.message is None

--- a/tests/unit/test_logrecord.py
+++ b/tests/unit/test_logrecord.py
@@ -106,7 +106,9 @@ def test_process_info():
     assert record.process == os.getpid()
     assert record.processName is None  # Not supported
 
+
 def test_logrecord_subclass():
     class DerivedLogRecord(LogRecord):
         pass
+
     assert DerivedLogRecord.__base__ is LogRecord

--- a/tests/unit/test_logrecord.py
+++ b/tests/unit/test_logrecord.py
@@ -105,3 +105,8 @@ def test_process_info():
     record = LogRecord("hello", logging.WARNING, __file__, 123, "bork", (), None)
     assert record.process == os.getpid()
     assert record.processName is None  # Not supported
+
+def test_logrecord_subclass():
+    class DerivedLogRecord(LogRecord):
+        pass
+    assert DerivedLogRecord.__base__ is LogRecord

--- a/tests/unit/test_logrecord.py
+++ b/tests/unit/test_logrecord.py
@@ -110,5 +110,10 @@ def test_process_info():
 def test_logrecord_subclass():
     class DerivedLogRecord(LogRecord):
         pass
+    record = DerivedLogRecord("hello", logging.WARNING, __file__, 123, "bork boom", (), None)
 
     assert DerivedLogRecord.__base__ is LogRecord
+    assert record.message is None
+    assert record.getMessage() == "bork boom"
+    assert record.message == "bork boom"
+    assert record.message == "bork boom"


### PR DESCRIPTION
I am currently checking for differences between CPython logging module and picologging by running the CPython logging tests, and this was the first issue it found: logging.LogRecord can be a base class, picologging.LogRecord cannot. I fixed that by adding the relevant flag to tp_flags and adding a test.