### PR TITLE
Properly raise error from Handler.emit

### DIFF
--- a/src/picologging/handler.cxx
+++ b/src/picologging/handler.cxx
@@ -46,7 +46,9 @@ PyObject* Handler_dealloc(Handler *self) {
 }
 
 PyObject* Handler_emit(Handler *self, PyObject *record){
-    Py_RETURN_NOTIMPLEMENTED;
+    PyErr_SetString(PyExc_NotImplementedError,
+                        "emit must be implemented by Handler subclasses");
+    return NULL;
 }
 
 PyObject* Handler_handle(Handler *self, PyObject *record) {

--- a/tests/unit/test_handler.py
+++ b/tests/unit/test_handler.py
@@ -7,7 +7,10 @@ def test_basic_handler():
     record = picologging.LogRecord(
         "test", picologging.INFO, "test", 1, "test", (), None, None, None
     )
-    handler.handle(record)
+    with pytest.raises(NotImplementedError):
+        handler.handle(record)
+    with pytest.raises(NotImplementedError):
+        handler.emit(None)
 
 
 def test_custom_handler():


### PR DESCRIPTION
The C code was previously returning the NotImplemented object, which is distinct from raising a NotImplemented error, so I changed it and added/modified a test. 