### PR TITLE
Properly handle return value for setStream

### DIFF
--- a/src/picologging/streamhandler.cxx
+++ b/src/picologging/streamhandler.cxx
@@ -92,6 +92,7 @@ PyObject* StreamHandler_setStream(StreamHandler* self, PyObject* stream){
     // Otherwise flush current stream
     PyObject* result = self->stream;
     flush(self);
+    Py_XDECREF(self->stream);
     // And set new stream
     self->stream = stream;
     Py_INCREF(self->stream);

--- a/src/picologging/streamhandler.cxx
+++ b/src/picologging/streamhandler.cxx
@@ -85,11 +85,19 @@ error:
 }
 
 PyObject* StreamHandler_setStream(StreamHandler* self, PyObject* stream){
-    Py_XDECREF(self->stream);
+    // If stream would be unchanged, do nothing and return None
+    if (self->stream == stream) {
+        Py_RETURN_NONE;
+    }
+    // Otherwise flush current stream
+    PyObject* result = self->stream;
+    flush(self);
+    // And set new stream
     self->stream = stream;
     Py_INCREF(self->stream);
     self->stream_has_flush = (PyObject_HasAttrString(self->stream, "flush") == 1);
-    Py_RETURN_NONE;
+    // Return previous stream (now flushed)
+    return result;
 }
 
 PyObject* StreamHandler_flush(StreamHandler* self, PyObject* const* args, Py_ssize_t nargs) {

--- a/tests/unit/test_streamhandler.py
+++ b/tests/unit/test_streamhandler.py
@@ -88,6 +88,7 @@ def test_set_stream():
     handler.setStream(b)
     assert handler.stream is b
 
+
 def test_set_stream_return_value():
     h = picologging.StreamHandler()
     stream = io.StringIO()

--- a/tests/unit/test_streamhandler.py
+++ b/tests/unit/test_streamhandler.py
@@ -87,3 +87,14 @@ def test_set_stream():
     b = TestStream()
     handler.setStream(b)
     assert handler.stream is b
+
+def test_set_stream_return_value():
+    h = picologging.StreamHandler()
+    stream = io.StringIO()
+    old = h.setStream(stream)
+    assert old is sys.stderr
+    actual = h.setStream(old)
+    assert actual is stream
+    # test that setting to existing value returns None
+    actual = h.setStream(old)
+    assert actual is None


### PR DESCRIPTION
StreamHandler.setStream has some very specific behavior that we weren't following. See https://docs.python.org/3/library/logging.handlers.html#logging.StreamHandler.setStream and the CPython code for reference.

This attempts to implement that behavior and adds a test for it.

I did end up removing a XDECREF on the old stream since it's now returned, not sure if that's problematic memory wise?