### PR TITLE
Fixing Stream.__repr__ to match CPython

### DIFF
--- a/src/picologging/streamhandler.cxx
+++ b/src/picologging/streamhandler.cxx
@@ -112,7 +112,7 @@ PyObject* StreamHandler_repr(StreamHandler *self)
     std::string level = _getLevelName(self->handler.level);
     return PyUnicode_FromFormat("<%s %U (%s)>",
         _PyType_Name(Py_TYPE(self)),
-        PyObject_Repr(PyObject_GetAttrString(self->stream, "name")),
+        PyObject_Str(PyObject_GetAttrString(self->stream, "name")),
         level.c_str());
 }
 

--- a/src/picologging/streamhandler.cxx
+++ b/src/picologging/streamhandler.cxx
@@ -3,6 +3,7 @@
 #include "streamhandler.hxx"
 #include "handler.hxx"
 #include "compat.hxx"
+#include "picologging.hxx"
 
 PyObject* StreamHandler_new(PyTypeObject* type, PyObject* args, PyObject* kwds)
 {
@@ -106,6 +107,15 @@ PyObject* StreamHandler_flush(StreamHandler* self, PyObject* const* args, Py_ssi
     Py_RETURN_NONE;
 }
 
+PyObject* StreamHandler_repr(StreamHandler *self)
+{
+    std::string level = _getLevelName(self->handler.level);
+    return PyUnicode_FromFormat("<%s %U (%s)>",
+        _PyType_Name(Py_TYPE(self)),
+        PyObject_Repr(PyObject_GetAttrString(self->stream, "name")),
+        level.c_str());
+}
+
 static PyMethodDef StreamHandler_methods[] = {
      {"emit", (PyCFunction)StreamHandler_emit, METH_FASTCALL, "Emit a record."},
      {"flush", (PyCFunction)StreamHandler_flush, METH_FASTCALL, "Flush the stream."},
@@ -128,7 +138,7 @@ PyTypeObject StreamHandlerType = {
     0,                                          /* tp_getattr */
     0,                                          /* tp_setattr */
     0,                                          /* tp_as_async */
-    0,                      /* tp_repr */
+   (reprfunc)StreamHandler_repr,                /* tp_repr */
     0,                                          /* tp_as_number */
     0,                                          /* tp_as_sequence */
     0,                                          /* tp_as_mapping */

--- a/tests/unit/test_streamhandler.py
+++ b/tests/unit/test_streamhandler.py
@@ -99,3 +99,18 @@ def test_set_stream_return_value():
     # test that setting to existing value returns None
     actual = h.setStream(old)
     assert actual is None
+
+def test_streamhandler_repr():
+    class StreamWithName(object):
+        level = picologging.NOTSET
+        name = 'beyonce'
+
+    handler = picologging.StreamHandler(StreamWithName())
+    assert repr(handler) == '<StreamHandler beyonce (NOTSET)>'
+
+    class StreamWithIntName(object):
+        level = picologging.NOTSET
+        name = 2
+
+    handler = picologging.StreamHandler(StreamWithIntName())
+    assert repr(handler) == '<StreamHandler 2 (NOTSET)>'

--- a/tests/unit/test_streamhandler.py
+++ b/tests/unit/test_streamhandler.py
@@ -100,17 +100,18 @@ def test_set_stream_return_value():
     actual = h.setStream(old)
     assert actual is None
 
+
 def test_streamhandler_repr():
     class StreamWithName(object):
         level = picologging.NOTSET
-        name = 'beyonce'
+        name = "beyonce"
 
     handler = picologging.StreamHandler(StreamWithName())
-    assert repr(handler) == '<StreamHandler beyonce (NOTSET)>'
+    assert repr(handler) == "<StreamHandler beyonce (NOTSET)>"
 
     class StreamWithIntName(object):
         level = picologging.NOTSET
         name = 2
 
     handler = picologging.StreamHandler(StreamWithIntName())
-    assert repr(handler) == '<StreamHandler 2 (NOTSET)>'
+    assert repr(handler) == "<StreamHandler 2 (NOTSET)>"


### PR DESCRIPTION
Fixes the format and allows "name" attribute to be a number.