### PR TITLE
Allow handle method to accept LogRecord subclasses

### DIFF
--- a/src/picologging/formatstyle.cxx
+++ b/src/picologging/formatstyle.cxx
@@ -180,7 +180,7 @@ PyObject* FormatStyle_validate(FormatStyle *self){
 
 PyObject* FormatStyle_format(FormatStyle *self, PyObject *record){
     if (self->defaults == Py_None){
-        if (LogRecord_CheckExact(record)){
+        if (LogRecord_Check(record)){
             _PyUnicodeWriter writer;
             _PyUnicodeWriter_Init(&writer);
             LogRecord* log_record = reinterpret_cast<LogRecord*>(record);

--- a/src/picologging/formatter.cxx
+++ b/src/picologging/formatter.cxx
@@ -83,7 +83,7 @@ int Formatter_init(Formatter *self, PyObject *args, PyObject *kwds){
 }
 
 PyObject* Formatter_format(Formatter *self, PyObject *record){
-    if (LogRecord_CheckExact(record)){
+    if (LogRecord_Check(record)){
         LogRecord* logRecord = (LogRecord*)record;
         LogRecord_writeMessage(logRecord);
         PyObject* result = nullptr;

--- a/src/picologging/logrecord.hxx
+++ b/src/picologging/logrecord.hxx
@@ -45,6 +45,7 @@ _PyTime_t current_time();
 
 
 extern PyTypeObject LogRecordType;
+#define LogRecord_CheckExact(op) Py_IS_TYPE(op, &LogRecordType)
 #define LogRecord_Check(op) PyObject_TypeCheck(op, &LogRecordType)
 
 typedef struct {

--- a/src/picologging/logrecord.hxx
+++ b/src/picologging/logrecord.hxx
@@ -45,7 +45,7 @@ _PyTime_t current_time();
 
 
 extern PyTypeObject LogRecordType;
-#define LogRecord_CheckExact(op) Py_IS_TYPE(op, &LogRecordType)
+#define LogRecord_Check(op) PyObject_TypeCheck(op, &LogRecordType)
 
 typedef struct {
     PyObject* filename;

--- a/tests/unit/test_logrecord.py
+++ b/tests/unit/test_logrecord.py
@@ -1,5 +1,6 @@
 import threading
 from picologging import LogRecord
+import picologging
 import logging
 import pytest
 import os
@@ -120,3 +121,6 @@ def test_logrecord_subclass():
     assert record.getMessage() == "bork boom"
     assert record.message == "bork boom"
     assert record.message == "bork boom"
+
+    handler = picologging.StreamHandler()
+    handler.emit(record)


### PR DESCRIPTION
In https://github.com/microsoft/picologging/pull/77 subclasses of LogRecord were added, but I think these checks will prevent `handle` to accept them.

Without the change the test would fail.