### PR TITLE
Allow Logger.propagate to be an int (or anything that evaluates to true)

### DIFF
--- a/src/picologging/__init__.pyi
+++ b/src/picologging/__init__.pyi
@@ -131,7 +131,7 @@ class Handler(Filterer):
     def createLock(self) -> None: ...
 
 class Logger(Filterer):
-    propagate: bool
+    propagate: object
     name: str
     level: int
     parent: Logger

--- a/src/picologging/logger.cxx
+++ b/src/picologging/logger.cxx
@@ -31,7 +31,7 @@ PyObject* Logger_new(PyTypeObject* type, PyObject* args, PyObject* kwds)
         Py_INCREF(self->name);
         self->parent = Py_None;
         Py_INCREF(self->parent);
-        self->propagate = true;
+        self->propagate = Py_True;
         self->handlers = PyList_New(0);
         if (self->handlers == NULL){
             Py_DECREF(self->parent);
@@ -545,7 +545,7 @@ static PyMethodDef Logger_methods[] = {
 static PyMemberDef Logger_members[] = {
     {"name", T_OBJECT_EX, offsetof(Logger, name), 0, "Logger name"},
     {"level", T_USHORT, offsetof(Logger, level), 0, "Logger level"},
-    {"propagate", T_BOOL, offsetof(Logger, propagate), 0, "Logger propagate"},
+    {"propagate", T_OBJECT_EX, offsetof(Logger, propagate), 0, "Logger propagate"},
     {"handlers", T_OBJECT_EX, offsetof(Logger, handlers), 0, "Logger handlers"},
     {"disabled", T_BOOL, offsetof(Logger, disabled), 0, "Logger disabled"},
     {"manager", T_OBJECT_EX, offsetof(Logger, manager), 0, "Logger manager"},

--- a/src/picologging/logger.hxx
+++ b/src/picologging/logger.hxx
@@ -15,7 +15,7 @@ typedef struct LoggerT {
     PyObject *name;
     unsigned short level;
     PyObject *parent;
-    bool propagate;
+    PyObject *propagate;
     PyObject *handlers;
     PyObject *manager;
     bool disabled;

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -469,17 +469,18 @@ def test_logger_setlevel_resets_other_levels():
     logger.error("test")
     assert stream.getvalue() == "test\ntest\n"
 
+
 def test_logger_propagate_int():
     stream1 = io.StringIO()
     handler1 = picologging.StreamHandler(stream1)
-    logger1 = picologging.getLogger('A')
+    logger1 = picologging.getLogger("A")
     logger1.propagate = 0
     logger1.addHandler(handler1)
     logger1.setLevel(picologging.WARNING)
 
     stream2 = io.StringIO()
     handler2 = picologging.StreamHandler(stream2)
-    logger2 = picologging.getLogger('A.B')
+    logger2 = picologging.getLogger("A.B")
     logger2.propagate = 0
     logger2.addHandler(handler2)
     logger2.setLevel(picologging.WARNING)
@@ -489,4 +490,3 @@ def test_logger_propagate_int():
     logger2.error("test2")
     assert stream1.getvalue() == "test1\n"
     assert stream2.getvalue() == "test2\n"
-

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -468,3 +468,25 @@ def test_logger_setlevel_resets_other_levels():
 
     logger.error("test")
     assert stream.getvalue() == "test\ntest\n"
+
+def test_logger_propagate_int():
+    stream1 = io.StringIO()
+    handler1 = picologging.StreamHandler(stream1)
+    logger1 = picologging.getLogger('A')
+    logger1.propagate = 0
+    logger1.addHandler(handler1)
+    logger1.setLevel(picologging.WARNING)
+
+    stream2 = io.StringIO()
+    handler2 = picologging.StreamHandler(stream2)
+    logger2 = picologging.getLogger('A.B')
+    logger2.propagate = 0
+    logger2.addHandler(handler2)
+    logger2.setLevel(picologging.WARNING)
+
+    logger1.error("test1")
+    assert stream1.getvalue() == "test1\n"
+    logger2.error("test2")
+    assert stream1.getvalue() == "test1\n"
+    assert stream2.getvalue() == "test2\n"
+


### PR DESCRIPTION
Logger.propagate can be any expression that evaluates to a Boolean, it does not have to be a Boolean, and in the CPython tests, it's often set with an int (0/1). Also in CPython comments its often described as 0/1. So, I don't know how commonly Python programmers are using an int for it, but this PR makes it compatible with CPython logging.