### PR TITLE
Add pylint config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,3 +15,6 @@ test-command = "python -X dev -m pytest {project}/tests"
 
 [tool.cibuildwheel.macos]
 environment = { MACOSX_DEPLOYMENT_TARGET = "10.15" }
+
+[tool.pylint.messages_control]
+disable = "C0114,C0115,C0116"


### PR DESCRIPTION
I find all the pylint warnings around docstrings distracting, and since it doesn't seem that docstrings are actually a high priority in this codebase, this config turns off the warnings. Let me know if you prefer a different approach.