### PR TITLE
Adding precommit with black and pyupgr

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -161,4 +161,4 @@ jobs:
     - name: Check Python Formatting
       run: black --check .
     - name: Check pyupgrade
-      run: pyupgrade --py37-plus src/picologging/*.py
+      run: pyupgrade --py37-plus src/picologging/*.py tests/**/*.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,15 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.3.0
+    hooks:
+    -   id: check-yaml
+-   repo: https://github.com/psf/black
+    rev: 22.3.0
+    hooks:
+    -   id: black
+        args: ['--config=./pyproject.toml']
+-   repo: https://github.com/asottile/pyupgrade
+    rev: v3.1.0
+    hooks:
+    -   id: pyupgrade
+        args: ['--py37-plus']

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Once opened in the dev container, run:
 
 ```
 pip install -e ".[dev]"
+pre-commit install
 python setup.py build_ext --inplace --build-type Debug
 ```
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from skbuild import setup
 from setuptools import find_packages
 
 
-with open("./README.md", "r") as fh:
+with open("./README.md") as fh:
     long_description = fh.read()
 
 
@@ -44,6 +44,7 @@ setup(
             "hypothesis",
             "flaky",
             "black",
+            "pre-commit",
         ]
     },
     project_urls={

--- a/tests/unit/test_bufferinghandler.py
+++ b/tests/unit/test_bufferinghandler.py
@@ -23,7 +23,7 @@ def test_memory_handler(tmp_path):
     logger.debug("test")
     handler.close()
 
-    with open(log_file, "r") as f:
+    with open(log_file) as f:
         assert f.read() == "test\n"
     assert handler.buffer == []
 
@@ -39,6 +39,6 @@ def test_memory_handler_set_target(tmp_path):
     logger.debug("test")
     handler.close()
 
-    with open(log_file, "r") as f:
+    with open(log_file) as f:
         assert f.read() == "test\n"
     assert handler.buffer == []

--- a/tests/unit/test_filehandler.py
+++ b/tests/unit/test_filehandler.py
@@ -22,7 +22,7 @@ def test_filehandler(tmp_path):
     logger.warning("test")
     handler.close()
 
-    with open(log_file, "r") as f:
+    with open(log_file) as f:
         assert f.read() == "test\n"
 
 
@@ -35,7 +35,7 @@ def test_filehandler_delay(tmp_path):
     logger.warning("test")
     handler.close()
 
-    with open(log_file, "r") as f:
+    with open(log_file) as f:
         assert f.read() == "test\n"
 
 
@@ -49,7 +49,7 @@ def test_watchedfilehandler(tmp_path):
     logger.warning("test")
     handler.close()
 
-    with open(log_file, "r") as f:
+    with open(log_file) as f:
         assert f.read() == "test\n"
 
 
@@ -68,7 +68,7 @@ def test_watchedfilehandler_file_changed(tmp_path):
     logger.warning("test")
     handler.close()
 
-    with open(log_file, "r") as f:
+    with open(log_file) as f:
         assert f.read() == "test\n"
 
 
@@ -85,7 +85,7 @@ def test_watchedfilehandler_file_removed(tmp_path):
     logger.warning("test")
     handler.close()
 
-    with open(log_file, "r") as f:
+    with open(log_file) as f:
         assert f.read() == "test\n"
 
 
@@ -100,13 +100,13 @@ def test_rotatingfilehandler(tmp_path):
         logger.warning("test")
     handler.close()
 
-    with open(log_file, "r") as f:
+    with open(log_file) as f:
         assert f.read() == "test\n"
 
     for i in range(1, 3):
         log_file = tmp_path / f"log.txt.{i}"
 
-        with open(log_file, "r") as f:
+        with open(log_file) as f:
             assert f.read() == "test\n"
 
 
@@ -187,7 +187,7 @@ def test_timed_rotatingfilehandler_rollover(tmp_path, utc):
     assert len(files) == 2
 
     for file_name in files:
-        with open(tmp_path / file_name, "r") as file:
+        with open(tmp_path / file_name) as file:
             assert file.read() == "test\n"
 
 

--- a/tests/unit/test_sockethandler.py
+++ b/tests/unit/test_sockethandler.py
@@ -89,7 +89,7 @@ class UDPServer(ControlMixin, ThreadingUDPServer):
                 data = self.wfile.getvalue()
                 if data:
                     try:
-                        super(DelegatingUDPRequestHandler, self).finish()
+                        super().finish()
                     except OSError:
                         if not self.server._closed:
                             raise

--- a/tests/unit/test_streamhandler.py
+++ b/tests/unit/test_streamhandler.py
@@ -102,14 +102,14 @@ def test_set_stream_return_value():
 
 
 def test_streamhandler_repr():
-    class StreamWithName(object):
+    class StreamWithName:
         level = picologging.NOTSET
         name = "beyonce"
 
     handler = picologging.StreamHandler(StreamWithName())
     assert repr(handler) == "<StreamHandler beyonce (NOTSET)>"
 
-    class StreamWithIntName(object):
+    class StreamWithIntName:
         level = picologging.NOTSET
         name = 2
 


### PR DESCRIPTION
As suggested in #109, this PR adds pre-commit hooks using the pre-commit package. To start off with, it has the yaml-fixer hook, the black hook, and the pyupgrade hook. I think it's nice to run pyupgrade on tests too, so I didn't exclude the tests from it, but I can exclude them if you feel otherwise.

I'll send a follow-up PR adding isort since that'll change a bunch of files.