### PR TITLE
Call dealloc of base types

### DIFF
--- a/src/picologging/handler.cxx
+++ b/src/picologging/handler.cxx
@@ -41,7 +41,7 @@ PyObject* Handler_dealloc(Handler *self) {
     Py_XDECREF(self->_const_emit);
     Py_XDECREF(self->_const_format);
     delete self->lock;
-    ((PyObject*)self)->ob_type->tp_free((PyObject*)self);
+    FiltererType.tp_dealloc((PyObject *)self);
     return nullptr;
 }
 

--- a/src/picologging/logger.cxx
+++ b/src/picologging/logger.cxx
@@ -132,7 +132,7 @@ PyObject* Logger_dealloc(Logger *self) {
     Py_XDECREF(self->_const_stack_info);
     Py_XDECREF(self->_const_line_break);
     Py_XDECREF(self->_fallback_handler);
-    Py_TYPE(self)->tp_free((PyObject*)self);
+    FiltererType.tp_dealloc((PyObject *)self);
     return NULL;
 }
 

--- a/src/picologging/streamhandler.cxx
+++ b/src/picologging/streamhandler.cxx
@@ -41,7 +41,7 @@ PyObject* StreamHandler_dealloc(StreamHandler *self) {
     Py_XDECREF(self->terminator);
     Py_XDECREF(self->_const_write);
     Py_XDECREF(self->_const_flush);
-    ((PyObject*)self)->ob_type->tp_free((PyObject*)self);
+    HandlerType.tp_dealloc((PyObject *)self);
     return nullptr;
 }
 


### PR DESCRIPTION
Per #116, this PR changes dealloc of Logger/Handler/StreamHandler to explicitly call the dealloc of their base type. That seems to be how it's done in CPython, from the examples I saw. And it seems to have reduced the memory leakage substantially.

memray before and after:

<img width="1720" alt="Screen Shot 2022-10-13 at 1 56 21 PM" src="https://user-images.githubusercontent.com/297042/195709222-b3ca04c4-0473-4edf-81e1-1de9f083a22b.png">

<img width="1722" alt="Screen Shot 2022-10-13 at 1 53 24 PM" src="https://user-images.githubusercontent.com/297042/195708748-9a5bc434-f6ac-4551-bbbb-38d64a7d1b40.png">

There seems to be one more memory leak around `self->usesTime = (FormatStyle_usesTime((FormatStyle*)self->style) == Py_True);`. It's not immediately obvious to me what the necessary change is for that one.