### PR TITLE
Fix `io` text_encoding on Python 3.9 and older

### DIFF
--- a/src/picologging/__init__.py
+++ b/src/picologging/__init__.py
@@ -15,7 +15,7 @@ from ._picologging import (
     getLevelName,
 )
 
-__version__ = "0.9.1"
+__version__ = "0.9.2"
 
 CRITICAL = 50
 FATAL = CRITICAL
@@ -27,6 +27,17 @@ DEBUG = 10
 NOTSET = 0
 
 BASIC_FORMAT = "%(levelname)s:%(name)s:%(message)s"
+
+
+if hasattr(io, "text_encoding"):
+    text_encoding = io.text_encoding
+else:
+    def text_encoding(encoding) -> str:
+        if encoding is not None:
+            return encoding
+        if sys.flags.utf8_mode:
+            return "utf-8"
+        return "locale"
 
 
 class PercentStyle(FormatStyle):
@@ -269,7 +280,7 @@ def basicConfig(**kwargs):
                 if "b" in mode:
                     errors = None
                 else:
-                    encoding = io.text_encoding(encoding)
+                    encoding = text_encoding(encoding)
                 h = FileHandler(filename, mode, encoding=encoding, errors=errors)
             else:
                 stream = kwargs.pop("stream", sys.stderr)

--- a/tests/unit/test_picologging.py
+++ b/tests/unit/test_picologging.py
@@ -1,4 +1,3 @@
-import logging
 import sys
 
 import pytest
@@ -146,3 +145,8 @@ def test_make_log_record():
     log_record = picologging.makeLogRecord({"levelno": picologging.WARNING})
 
     assert log_record.levelno == picologging.WARNING
+
+
+@pytest.mark.parametrize("encoding", ["utf-8", None])
+def test_basic_config_encoding(encoding):
+    picologging.basicConfig(filename='test.txt', encoding=encoding)


### PR DESCRIPTION
Fixes https://github.com/microsoft/picologging/issues/142