### PR TITLE
Improve the performance of logging records by inlining log creation to remove temporary Python objects into the logger.

### DIFF
--- a/src/picologging/logrecord.cxx
+++ b/src/picologging/logrecord.cxx
@@ -49,7 +49,10 @@ PyObject* LogRecord_new(PyTypeObject* type, PyObject *initargs, PyObject *kwds)
         PyErr_NoMemory();
         return NULL;
     }
+    return (PyObject*)LogRecord_create(self, name, msg, args, levelno, pathname, lineno, exc_info, funcname, sinfo);
+}
 
+LogRecord* LogRecord_create(LogRecord* self, PyObject* name, PyObject* msg, PyObject* args, int levelno, PyObject* pathname, int lineno, PyObject* exc_info, PyObject* funcname, PyObject* sinfo) {
     self->name = Py_NewRef(name);
     self->msg = Py_NewRef(msg);
 
@@ -77,6 +80,7 @@ PyObject* LogRecord_new(PyTypeObject* type, PyObject *initargs, PyObject *kwds)
     self->args = Py_NewRef(args);
 
     self->levelno = levelno;
+    PyObject* levelname = nullptr;
     switch (levelno) {
         case LOG_LEVEL_CRITICAL:
             levelname = PyUnicode_FromString("CRITICAL");
@@ -167,7 +171,7 @@ PyObject* LogRecord_new(PyTypeObject* type, PyObject *initargs, PyObject *kwds)
     self->process = getpid();
     self->message = Py_NewRef(Py_None);
     self->asctime = Py_NewRef(Py_None);
-    return (PyObject*)self;;
+    return self;
 
 error:
     Py_XDECREF(self->name);
@@ -189,7 +193,7 @@ error:
     if (!PyErr_Occurred()) {
         PyErr_Format(PyExc_ValueError, "Could not create LogRecord, unknown error.");
     }
-    return NULL;
+    return nullptr;
 }
 
 PyObject* LogRecord_dealloc(LogRecord *self)

--- a/src/picologging/logrecord.hxx
+++ b/src/picologging/logrecord.hxx
@@ -36,6 +36,7 @@ typedef struct {
 } LogRecord;
 
 int LogRecord_init(LogRecord *self, PyObject *args, PyObject *kwds);
+LogRecord* LogRecord_create(LogRecord* self, PyObject* name, PyObject* msg, PyObject* args, int levelno, PyObject* pathname, int lineno, PyObject* exc_info, PyObject* funcname, PyObject* sinfo) ;
 PyObject* LogRecord_dealloc(LogRecord *self);
 int LogRecord_writeMessage(LogRecord *self);
 PyObject* LogRecord_getMessage(LogRecord *self);


### PR DESCRIPTION
Closes #185 