### PR TITLE
Improve performance of Formatter.format

### DIFF
--- a/src/picologging/formatstyle.cxx
+++ b/src/picologging/formatstyle.cxx
@@ -96,6 +96,7 @@ int FormatStyle_init(FormatStyle *self, PyObject *args, PyObject *kwds){
     }
 
     self->fmt = Py_NewRef(fmt);
+    self->fmt_len = PyUnicode_GET_LENGTH(fmt);
 
     std::string const format_string(PyUnicode_AsUTF8(fmt));
     auto fragments_begin = std::sregex_iterator(format_string.begin(), format_string.end(), fragment_search);
@@ -184,6 +185,8 @@ PyObject* FormatStyle_format(FormatStyle *self, PyObject *record){
         if (LogRecord_CheckExact(record) || LogRecord_Check(record)){
             _PyUnicodeWriter writer;
             _PyUnicodeWriter_Init(&writer);
+            writer.overallocate = 1;
+            writer.min_length = self->fmt_len + 100;
             LogRecord* log_record = reinterpret_cast<LogRecord*>(record);
             for (int i = 0 ; i < self->ob_base.ob_size ; i++){
                 switch (self->fragments[i].field){

--- a/src/picologging/formatstyle.hxx
+++ b/src/picologging/formatstyle.hxx
@@ -45,6 +45,7 @@ typedef struct {
 typedef struct {
     PyObject_VAR_HEAD
     PyObject *fmt;
+    Py_ssize_t fmt_len;
     PyObject *defaults;
     bool usesDefaultFmt;
     int style;


### PR DESCRIPTION
Preallocate the string writer based on the length of the fmt string. Reduces the number of times a reallocation is done on the formatted string.