### PR TITLE
Fix asctime formatting, don't print uninitialized buffer's content (issue #203)

### DIFF
--- a/src/picologging/__init__.py
+++ b/src/picologging/__init__.py
@@ -177,7 +177,9 @@ class Manager:
         self.cls = klass
 
     def setLogRecordFactory(self, factory):
-        raise NotImplementedError("setLogRecordFactory is not supported in picologging.")
+        raise NotImplementedError(
+            "setLogRecordFactory is not supported in picologging."
+        )
 
 
 root = Logger(name="root", level=WARNING)

--- a/src/picologging/formatter.cxx
+++ b/src/picologging/formatter.cxx
@@ -102,7 +102,7 @@ PyObject* Formatter_format(Formatter *self, PyObject *record){
             } else {
                 char buf[100];
                 size_t len = strftime(buf, sizeof(buf), "%F %T" , ct);
-                len += snprintf(buf + len, sizeof(buf) - len, ".%03d", createdFrac);
+                len += snprintf(buf + len, sizeof(buf) - len, ",%03d", createdFrac);
                 asctime = PyUnicode_FromStringAndSize(buf, len);
             }
 

--- a/src/picologging/formatter.cxx
+++ b/src/picologging/formatter.cxx
@@ -90,7 +90,7 @@ PyObject* Formatter_format(Formatter *self, PyObject *record){
             return nullptr;
         }
         if (self->usesTime){
-            PyObject* asctime = Py_None;
+            PyObject * asctime = Py_None;
             double createdInt;
             int createdFrac = std::modf(logRecord->created, &createdInt) * 1e6;
             std::time_t created = static_cast<std::time_t>(createdInt);

--- a/src/picologging/formatter.cxx
+++ b/src/picologging/formatter.cxx
@@ -92,7 +92,7 @@ PyObject* Formatter_format(Formatter *self, PyObject *record){
         if (self->usesTime){
             PyObject * asctime = Py_None;
             double createdInt;
-            int createdFrac = std::modf(logRecord->created, &createdInt) * 1e6;
+            int createdFrac = std::modf(logRecord->created, &createdInt) * 1e3;
             std::time_t created = static_cast<std::time_t>(createdInt);
             std::tm *ct = localtime(&created);
             if (self->dateFmt != Py_None){
@@ -102,7 +102,7 @@ PyObject* Formatter_format(Formatter *self, PyObject *record){
             } else {
                 char buf[100];
                 size_t len = strftime(buf, sizeof(buf), "%F %T" , ct);
-                len += snprintf(buf + len, sizeof(buf) - len, ".%06d", createdFrac);
+                len += snprintf(buf + len, sizeof(buf) - len, ".%03d", createdFrac);
                 asctime = PyUnicode_FromStringAndSize(buf, len);
             }
 

--- a/src/picologging/formatter.cxx
+++ b/src/picologging/formatter.cxx
@@ -1,4 +1,5 @@
 #include <ctime>
+#include <charconv>
 #include "picologging.hxx"
 #include "formatter.hxx"
 #include "formatstyle.hxx"
@@ -89,16 +90,20 @@ PyObject* Formatter_format(Formatter *self, PyObject *record){
             return nullptr;
         }
         if (self->usesTime){
-            PyObject * asctime = Py_None;
-            std::time_t created = (std::time_t)logRecord->created;
+            PyObject* asctime = Py_None;
+            double createdInt;
+            int createdFrac = std::modf(logRecord->created, &createdInt) * 1e6;
+            std::time_t created = static_cast<std::time_t>(createdInt);
             std::tm *ct = localtime(&created);
             if (self->dateFmt != Py_None){
                 char buf[100];
-                size_t len = strftime(buf, 100, self->dateFmtStr, ct);
+                size_t len = strftime(buf, sizeof(buf), self->dateFmtStr, ct);
                 asctime = PyUnicode_FromStringAndSize(buf, len);
             } else {
                 char buf[100];
-                asctime = PyUnicode_FromFormat("%s,%03d", buf, logRecord->msecs);
+                size_t len = strftime(buf, sizeof(buf), "%F %T" , ct);
+                len += snprintf(buf + len, sizeof(buf) - len, ".%06d", createdFrac);
+                asctime = PyUnicode_FromStringAndSize(buf, len);
             }
 
             Py_XDECREF(logRecord->asctime);

--- a/tests/unit/test_formatter.py
+++ b/tests/unit/test_formatter.py
@@ -156,7 +156,7 @@ def test_asctime_field_buffer():
     )
     logging_f = LoggingFormatter("%(asctime)s")
 
-    assert pico_f.format(record).split(',')[0] == logging_f.format(record).split(',')[0]
+    assert pico_f.format(record).split(",")[0] == logging_f.format(record).split(",")[0]
     assert pico_f.usesTime()
 
 

--- a/tests/unit/test_formatter.py
+++ b/tests/unit/test_formatter.py
@@ -3,12 +3,12 @@ import io
 import logging
 import sys
 import traceback
+from logging import Formatter as LoggingFormatter
 
 import pytest
 from utils import filter_gc
 
 from picologging import Formatter, LogRecord
-from logging import Formatter as LoggingFormatter
 
 
 @pytest.mark.limit_leaks("192B", filter_fn=filter_gc)

--- a/tests/unit/test_formatter.py
+++ b/tests/unit/test_formatter.py
@@ -156,7 +156,7 @@ def test_asctime_field_buffer():
     )
     logging_f = LoggingFormatter("%(asctime)s")
 
-    assert pico_f.format(record) == logging_f.format(record)
+    assert pico_f.format(record).split(',')[0] == logging_f.format(record).split(',')[0]
     assert pico_f.usesTime()
 
 


### PR DESCRIPTION
Closes https://github.com/microsoft/picologging/issues/203
Correctly format and print LogRecord.asctime field

Please merge this PR or https://github.com/microsoft/picologging/pull/209
where %f support in datefmt was also added. 

```
import time
import picologging as logging

logging.basicConfig(format="%(levelname)s - %(asctime)s - %(name)s - %(module)s - %(message)s")
logger = logging.getLogger()
logger.setLevel(logging.INFO)

if __name__ == '__main__':
    for i in range(5):
        time.sleep(0.4)
        logger.info("Hello world! %d", i)
```

```
INFO - 2024-07-23 04:35:30,285 - root - <unknown> - Hello world! 0
INFO - 2024-07-23 04:35:30,685 - root - <unknown> - Hello world! 1
INFO - 2024-07-23 04:35:31,085 - root - <unknown> - Hello world! 2
INFO - 2024-07-23 04:35:31,485 - root - <unknown> - Hello world! 3
INFO - 2024-07-23 04:35:31,886 - root - <unknown> - Hello world! 4
```