### PR TITLE
Feature/microseconds formatter support

### DIFF
--- a/src/picologging/formatter.cxx
+++ b/src/picologging/formatter.cxx
@@ -90,7 +90,7 @@ PyObject* Formatter_format(Formatter *self, PyObject *record){
             return nullptr;
         }
         if (self->usesTime){
-            PyObject* asctime = Py_None;
+            PyObject * asctime = Py_None;
             double createdInt;
             int createdFrac = std::modf(logRecord->created, &createdInt) * 1e6;
             std::time_t created = static_cast<std::time_t>(createdInt);

--- a/src/picologging/formatter.cxx
+++ b/src/picologging/formatter.cxx
@@ -92,7 +92,7 @@ PyObject* Formatter_format(Formatter *self, PyObject *record){
         if (self->usesTime){
             PyObject * asctime = Py_None;
             double createdInt;
-            int createdFrac = std::modf(logRecord->created, &createdInt) * 1e6;
+            int createdFrac = std::modf(logRecord->created, &createdInt) * 1e3;
             std::time_t created = static_cast<std::time_t>(createdInt);
             std::tm *ct = localtime(&created);
             if (self->dateFmt != Py_None){
@@ -102,7 +102,7 @@ PyObject* Formatter_format(Formatter *self, PyObject *record){
             } else {
                 char buf[100];
                 size_t len = strftime(buf, sizeof(buf), "%F %T" , ct);
-                len += snprintf(buf + len, sizeof(buf) - len, ".%06d", createdFrac);
+                len += snprintf(buf + len, sizeof(buf) - len, ".%03d", createdFrac);
                 asctime = PyUnicode_FromStringAndSize(buf, len);
             }
 

--- a/src/picologging/formatter.cxx
+++ b/src/picologging/formatter.cxx
@@ -1,4 +1,5 @@
 #include <ctime>
+#include <charconv>
 #include "picologging.hxx"
 #include "formatter.hxx"
 #include "formatstyle.hxx"
@@ -89,16 +90,20 @@ PyObject* Formatter_format(Formatter *self, PyObject *record){
             return nullptr;
         }
         if (self->usesTime){
-            PyObject * asctime = Py_None;
-            std::time_t created = (std::time_t)logRecord->created;
+            PyObject* asctime = Py_None;
+            double createdInt;
+            int createdFrac = std::modf(logRecord->created, &createdInt) * 1e6;
+            std::time_t created = static_cast<std::time_t>(createdInt);
             std::tm *ct = localtime(&created);
             if (self->dateFmt != Py_None){
                 char buf[100];
-                size_t len = strftime(buf, 100, self->dateFmtStr, ct);
+                size_t len = strftime(buf, sizeof(buf), self->dateFmtStr, ct);
                 asctime = PyUnicode_FromStringAndSize(buf, len);
             } else {
                 char buf[100];
-                asctime = PyUnicode_FromFormat("%s,%03d", buf, logRecord->msecs);
+                size_t len = strftime(buf, sizeof(buf), "%F %T" , ct);
+                len += snprintf(buf + len, sizeof(buf) - len, ".%06d", createdFrac);
+                asctime = PyUnicode_FromStringAndSize(buf, len);
             }
 
             Py_XDECREF(logRecord->asctime);

--- a/src/picologging/formatter.hxx
+++ b/src/picologging/formatter.hxx
@@ -12,7 +12,9 @@ typedef struct {
     PyObject *dateFmt;
     PyObject *style;
     bool usesTime;
-    const char* dateFmtStr;
+    size_t dateFmtMicrosendsPos;        // If %f specified in dateFmt then points to '%' character, otherwise std::string_view::npos
+    size_t dateFmtStrSize;              // Size of the dateFmt without null terminator
+    const char* dateFmtStr;             // C-string, null terminated
     PyObject *_const_line_break;
     PyObject *_const_close;
     PyObject *_const_getvalue;


### PR DESCRIPTION
Closes https://github.com/microsoft/picologging/issues/184 ,
also closes https://github.com/microsoft/picologging/issues/203 because it was the same part of code that had to changed

Please merge this PR or  https://github.com/microsoft/picologging/pull/208

```
import picologging as logging

logging.basicConfig(format="%(levelname)s - %(asctime)s - %(name)s - %(module)s - %(message)s", datefmt="%F %T.%f")
logger = logging.getLogger()
logger.setLevel(logging.INFO)

if __name__ == '__main__':
    for i in range(5):
        logger.info("Hello world! %d", i)
```

```
INFO - 2024-07-23 04:15:56.170199 - root - <unknown> - Hello world! 0
INFO - 2024-07-23 04:15:56.170242 - root - <unknown> - Hello world! 1
INFO - 2024-07-23 04:15:56.170255 - root - <unknown> - Hello world! 2
INFO - 2024-07-23 04:15:56.170265 - root - <unknown> - Hello world! 3
INFO - 2024-07-23 04:15:56.170274 - root - <unknown> - Hello world! 4
```