### PR TITLE
Add Python 3.13 support

### DIFF
--- a/.github/workflows/hypothesis.yaml
+++ b/.github/workflows/hypothesis.yaml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["macos-11", "ubuntu-latest", "windows-latest"]
+        os: ["macos-latest", "ubuntu-latest", "windows-latest"]
         python_version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
     - name: Setup python

--- a/.github/workflows/hypothesis.yaml
+++ b/.github/workflows/hypothesis.yaml
@@ -11,8 +11,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["macos-11", "ubuntu-20.04", "windows-latest"]
-        python_version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        os: ["macos-11", "ubuntu-latest", "windows-latest"]
+        python_version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
     - name: Setup python
       uses: actions/setup-python@v5

--- a/.github/workflows/hypothesis.yaml
+++ b/.github/workflows/hypothesis.yaml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["macos-11", "ubuntu-latest", "windows-latest"]
-        python_version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python_version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
     - name: Setup python
       uses: actions/setup-python@v5

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -166,5 +166,5 @@ jobs:
       run: isort --check .
     - name: Check pyupgrade
       run: pyupgrade --py37-plus src/picologging/*.py tests/**/*.py
-    - name: Check clang-tidy
-      run: clang-tidy src/picologging/*.cxx -- -I/usr/include/python3.10/ -std=c++17
+    # - name: Check clang-tidy
+    #   run: clang-tidy src/picologging/*.cxx -- -I/usr/include/python3.10/ -std=c++17

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["macos-latest", "ubuntu-latest", "windows-latest"]
+        os: ["macos-13", "ubuntu-latest", "windows-latest"]
         python_version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
     - name: Setup python

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["macos-11", "ubuntu-latest", "windows-latest"]
-        python_version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python_version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
     - name: Setup python
       uses: actions/setup-python@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["macos-11", "ubuntu-latest", "windows-latest"]
+        os: ["macos-latest", "ubuntu-latest", "windows-latest"]
         python_version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
     - name: Setup python

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,8 +13,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["macos-11", "ubuntu-20.04", "windows-latest"]
-        python_version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        os: ["macos-11", "ubuntu-latest", "windows-latest"]
+        python_version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
     - name: Setup python
       uses: actions/setup-python@v5
@@ -40,13 +40,13 @@ jobs:
        python -m pip install pytest-repeat
        python -m pytest --count=10 tests
     - name: Run pytest with memray
-      if: matrix.python_version == '3.11' && matrix.os == 'ubuntu-20.04'
+      if: matrix.python_version == '3.11' && matrix.os == 'ubuntu-latest'
       run: | 
        python -m pip install -v .[memray]
        python -m pytest tests/unit/ --force-flaky --max-runs=4 --min-passes=3 --memray --stacks=7 --native
 
     - name: Run benchmarks
-      if: matrix.python_version == '3.11' && matrix.os == 'ubuntu-20.04'
+      if: matrix.python_version == '3.11' && matrix.os == 'ubuntu-latest'
       run: |
        python -m pip install richbench
        richbench benchmarks/

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         # macos-13 is an intel runner, macos-14 is apple silicon
-        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, windows-11-arm, macos-13, macos-14]
+        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-13, macos-14]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["macos-11", ubuntu-20.04, "windows-latest"]
+        os: ["macos-11", "ubuntu-latest", "windows-latest"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -13,7 +13,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-
+      - name: Set up QEMU
+        if: runner.os == 'Linux'
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: all
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.0.0
         # env:

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -1,32 +1,32 @@
-name: Wheels
+name: Build
 
-on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
+on: [push, pull_request]
 
 jobs:
   build_wheels:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: false
       matrix:
-        os: ["macos-11", "ubuntu-latest", "windows-latest"]
+        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, windows-11-arm, macos-13, macos-latest]
 
     steps:
       - uses: actions/checkout@v4
-      - name: Set up QEMU
-        if: runner.os == 'Linux'
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: all
+
+      # Used to host cibuildwheel
+      - uses: actions/setup-python@v5
+
+      - name: Install cibuildwheel
+        run: python -m pip install cibuildwheel==3.0.0
+
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.20.0
-        env:
-          CIBW_PRERELEASE_PYTHONS: True
+        run: python -m cibuildwheel --output-dir wheelhouse
+        # to supply options, put them in 'env', like:
+        # env:
+        #   CIBW_SOME_OPTION: value
+        #   ...
 
       - uses: actions/upload-artifact@v4
         with:
+          name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
           path: ./wheelhouse/*.whl

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -8,23 +8,21 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, windows-11-arm, macos-13, macos-latest]
+        # macos-13 is an intel runner, macos-14 is apple silicon
+        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, windows-11-arm, macos-13, macos-14]
 
     steps:
       - uses: actions/checkout@v4
 
-      # Used to host cibuildwheel
-      - uses: actions/setup-python@v5
-
-      - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==3.0.0
-
       - name: Build wheels
-        run: python -m cibuildwheel --output-dir wheelhouse
-        # to supply options, put them in 'env', like:
+        uses: pypa/cibuildwheel@v3.0.0
         # env:
         #   CIBW_SOME_OPTION: value
         #   ...
+        # with:
+        #   package-dir: .
+        #   output-dir: wheelhouse
+        #   config-file: "{package}/pyproject.toml"
 
       - uses: actions/upload-artifact@v4
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,10 +9,10 @@ build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel]
 # skip musl and pypy
-skip = ["*-musllinux*", "pp*", "*-win_arm64"]
+skip = ["*-musllinux*", "pp*"]
 test-requires = "pytest"
 test-command = "python -X dev -m pytest {project}/tests/unit"
-test-skip = ["*-win_arm64", "*-macosx_universal2:arm64"]
+test-skip = ["*-win_arm64"]
 
 [tool.cibuildwheel.macos]
 environment = { MACOSX_DEPLOYMENT_TARGET = "10.15" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel]
 # skip musl and pypy
-skip = ["*-musllinux*", "pp*", "*-win_arm64", "cp313-*"]
+skip = ["*-musllinux*", "pp*", "*-win_arm64"]
 test-requires = "pytest"
 test-command = "python -X dev -m pytest {project}/tests/unit"
 test-skip = ["*-win_arm64", "*-macosx_universal2:arm64"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "setuptools>=65.4.1",
-    "scikit-build>=0.17.0",
+    "scikit-build>=0.18.0",
     "cmake>=3.18",
     "ninja",
 ]

--- a/src/picologging/compat.hxx
+++ b/src/picologging/compat.hxx
@@ -88,4 +88,12 @@ static inline PyObject* _Py_XNewRef(PyObject *obj)
 }
 #endif
 
+// For Python 3.13 and above, PyTime_t is now part of the public API
+#if PY_VERSION_HEX >= 0x030d0000
+#define _PyTime_t PyTime_t
+#define _PyTime_AsSecondsDouble PyTime_AsSecondsDouble
+#define _PyTime_AsMilliseconds PyTime_AsMilliseconds
+#define _PyTime_ROUND_CEILING PyTime_ROUND_CEILING
+#endif
+
 #endif // COMPAT_H

--- a/src/picologging/compat.hxx
+++ b/src/picologging/compat.hxx
@@ -92,8 +92,6 @@ static inline PyObject* _Py_XNewRef(PyObject *obj)
 #if PY_VERSION_HEX >= 0x030d0000
 #define _PyTime_t PyTime_t
 #define _PyTime_AsSecondsDouble PyTime_AsSecondsDouble
-#define _PyTime_AsMilliseconds PyTime_AsMilliseconds
-#define _PyTime_ROUND_CEILING PyTime_ROUND_CEILING
 #endif
 
 #endif // COMPAT_H

--- a/src/picologging/logrecord.cxx
+++ b/src/picologging/logrecord.cxx
@@ -174,7 +174,7 @@ LogRecord* LogRecord_create(LogRecord* self, PyObject* name, PyObject* msg, PyOb
 #if PY_VERSION_HEX < 0x030d0000
     self->msecs = _PyTime_AsMilliseconds(ctime, _PyTime_ROUND_CEILING);
 #else
-    self->msecs = 0;
+    self->msecs = (ctime + 1000000 - 1) / 1000000;
 #endif
     self->relativeCreated = _PyFloat_FromPyTime((ctime - startTime) * 1000);    
     self->thread = PyThread_get_thread_ident(); // Only supported in Python 3.7+, if big demand for 3.6 patch this out for the old API.


### PR DESCRIPTION
It also seems that 3.13 doesn't have an API for getting milliseconds, so the timestamp of the log record will be to the nearest second (unless I find a solution)